### PR TITLE
Fix decimal normalization for trailing separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
+# PDF & Satış Analiz Aracı
 
+Bu depo, PDF dosyalarındaki para birimi tutarlarını ve satış Excel dosyalarını analiz etmek için geliştirilen Streamlit tabanlı uygulamayı içerir.
+
+## Geliştirilmiş `app.py` dosyasını üretim ortamına aktarma
+
+Aşağıdaki adımlar, burada düzeltilen `app.py` dosyasını kendi Streamlit sunucunuza veya VPS'inize taşımanıza yardımcı olur:
+
+1. **Depodaki son değişikliği çekin**  
+   Sunucunuzda ya da geliştirici bilgisayarınızda depo klasörüne girin ve güncel dosyaları alın:
+   ```bash
+   cd pdf-para-tespit-uygulamasi
+   git pull origin main
+   ```
+
+2. **Yereldeki `app.py` dosyasını kopyalayın**  
+   Eğer dosyayı manuel olarak aktarmak istiyorsanız, güncel `app.py` dosyasını SCP/SFTP ile sunucunuza gönderin:
+   ```bash
+   scp app.py user@sunucu-adresi:/path/to/pdf-para-tespit-uygulamasi/app.py
+   ```
+   > `user`, `sunucu-adresi` ve hedef yolu kendi ortamınıza göre düzenleyin.
+
+3. **Streamlit servisiniz varsa yeniden başlatın**  
+   * Streamlit Cloud kullanıyorsanız depo güncellemesi otomatik olarak yeni sürümü kullanır.  
+   * Kendi VPS'inizde çalıştırıyorsanız süreci yeniden başlatın:
+     ```bash
+     pkill streamlit  # servis arka planda çalışıyorsa
+     streamlit run app.py --server.port 8501
+     ```
+
+4. **Değişiklikleri doğrulayın**  
+   Tarayıcıda uygulamanızı açarak PDF toplamlarının doğru göründüğünü kontrol edin.
+
+## Uygulamayı çalıştırma
+
+1. Bağımlılıkları yükleyin:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Uygulamayı başlatın:
+   ```bash
+   streamlit run app.py
+   ```
+3. Tarayıcıdan `http://localhost:8501` adresine giderek arayüzü kullanın.
+
+## Destek
+
+Bir sorunla karşılaşırsanız GitHub Issues veya e-posta üzerinden geri bildirim gönderebilirsiniz.

--- a/app.py
+++ b/app.py
@@ -35,6 +35,15 @@ def normalize_number_str(s: str) -> str:
     s = s.strip()
     # önce boşluk ve para birimi yazılarını ayıkla
     s = re.sub(r"[^\d,.\-]", "", s)
+
+    # Bazı PDF çıktılarında sayıların sonunda fazladan nokta/virgül olabiliyor
+    # (örn. "6,30."), bu durum ondalık kısmın düşmesine sebep oluyordu.
+    # Hem baştaki hem sondaki ayracı temizleyelim.
+    while s and s[-1] in ",.":
+        s = s[:-1]
+    while s and s[0] in ",.":
+        s = s[1:]
+
     if s.count(",") == 1 and s.count(".") >= 1:
         # binlik . ve ondalık , varsay → noktaları sil, virgülü noktaya çevir
         s = s.replace(".", "")


### PR DESCRIPTION
## Summary
- trim leading and trailing comma/dot characters before normalizing PDF number strings
- prevent the decimal portion from being dropped when extracted totals include trailing punctuation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e656e683c88320ae7ab3f1574df4bd